### PR TITLE
Refactor StaffTable component to comment out unused username column a…

### DIFF
--- a/src/app/admin/staff/StaffTable.tsx
+++ b/src/app/admin/staff/StaffTable.tsx
@@ -113,12 +113,15 @@ export default function StaffTable({
         </thead>
         <tbody className="bg-white divide-y divide-gray-200">
           {loading2 ? (
-          <tr>
-            <td colSpan={5} className="px-4 py-4 text-center text-sm text-tableText2 font-medium">
-              Loading...
-            </td>
-          </tr>
-        ) : staffData.length === 0 ? (
+            <tr>
+              <td
+                colSpan={5}
+                className="px-4 py-4 text-center text-sm text-tableText2 font-medium"
+              >
+                Loading...
+              </td>
+            </tr>
+          ) : staffData.length === 0 ? (
             <tr className="border-b">
               <td
                 colSpan={4}
@@ -163,10 +166,10 @@ export default function StaffTable({
                 <td className="px-4 py-4 whitespace-nowrap text-sm text-tableText2 font-medium">
                   {staff.status}
                 </td>
-                {/* <td className="px-4 py-4 whitespace-nowrap text-sm text-tableText2 font-medium">
+                <td className="px-4 py-4 whitespace-nowrap text-sm text-tableText2 font-medium">
                   {staff.username}
                 </td>
-                <td className="px-4 py-4 whitespace-nowrap text-sm text-tableText2 font-medium flex flex-col justify-end relative">
+                {/* <td className="px-4 py-4 whitespace-nowrap text-sm text-tableText2 font-medium flex flex-col justify-end relative">
                   <p
                     onClick={() => toggleVisibility(staff.id)}
                     aria-expanded={editOptions[staff.id] || false}

--- a/src/app/admin/staff/StaffTable.tsx
+++ b/src/app/admin/staff/StaffTable.tsx
@@ -163,7 +163,7 @@ export default function StaffTable({
                 <td className="px-4 py-4 whitespace-nowrap text-sm text-tableText2 font-medium">
                   {staff.status}
                 </td>
-                <td className="px-4 py-4 whitespace-nowrap text-sm text-tableText2 font-medium">
+                {/* <td className="px-4 py-4 whitespace-nowrap text-sm text-tableText2 font-medium">
                   {staff.username}
                 </td>
                 <td className="px-4 py-4 whitespace-nowrap text-sm text-tableText2 font-medium flex flex-col justify-end relative">
@@ -182,13 +182,13 @@ export default function StaffTable({
                       className="bg-white shadow-lg rounded-lg p-4 font-medium w-32 absolute top-full border-2 right-20 text-tblack3 space-y-4 "
                     >
                       {/* <p className="hover:text-gold1 cursor-pointer">Edit</p>
-                      <hr /> */}
+                      <hr /> 
                       <p className="text-tred1 hover:text-gold1 cursor-pointer">
                         Archive
                       </p>
                     </div>
                   )}
-                </td>
+                </td> */}
               </tr>
             ))
           )}

--- a/src/app/api/getRoles/route.ts
+++ b/src/app/api/getRoles/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
   // Extract any query parameters
   const { searchParams } = new URL(req.url);
   const sort = searchParams.get("sort") || "";
-  
+
   let endpoint = "/v1/admin/roles";
   if (sort) {
     endpoint += `?sort=${sort}`;
@@ -25,8 +25,8 @@ export async function GET(req: NextRequest) {
         Authorization: `Bearer ${accessToken}`,
         "Content-Type": "application/json",
       },
-      cache: "force-cache",
-      next: { tags: ["roles"] },
+      cache: "no-store", // Use no-store to prevent caching issues with filters
+      next: { revalidate: 0 }, // Disable caching
     });
 
     if (response.ok) {


### PR DESCRIPTION
This pull request includes minor UI adjustments to the staff table and an update to the API route for fetching roles to improve data freshness by disabling caching.

API improvements:

* Updated the `GET` handler in `src/app/api/getRoles/route.ts` to use `cache: "no-store"` and `next: { revalidate: 0 }`, ensuring that role data is always fetched fresh and not cached.

UI adjustments:

* Commented out the table cell displaying `staff.username` and its related menu in `StaffTable`, effectively hiding the username column and associated UI from the staff table. [[1]](diffhunk://#diff-c8693e9ebddd0e321e423b6345cf1f37ead5940369047423775ff1bed36adb96L166-R166) [[2]](diffhunk://#diff-c8693e9ebddd0e321e423b6345cf1f37ead5940369047423775ff1bed36adb96L185-R191)…nd update role fetching logic to prevent caching issues