### PR TITLE
Refactor logout API to use cookie store for deleting tokens and impro…

### DIFF
--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,40 +1,46 @@
 import { NextRequest, NextResponse } from "next/server";
+import { cookies } from 'next/headers';
 
 export async function POST(req: NextRequest) {
-  const res = new NextResponse(
+   const isProduction = process.env.NODE_ENV === "production" || process.env.NEXT_PUBLIC_VERCEL_ENV === "production" || process.env.NEXT_PUBLIC_VERCEL_ENV === "staging";
+  
+  const cookieOptions = {
+    domain: isProduction ? '.audease.co.uk' : undefined,
+    secure: isProduction,
+    httpOnly: true,
+    path: '/',
+    expires: new Date(0), // Set to past date to delete
+    maxAge: 0,
+  };
+
+  const cookieStore = await cookies();
+  
+  // Delete cookies with the same domain they were set with
+  cookieStore.set({
+    ...cookieOptions,
+    name: 'accessToken',
+    value: '',
+  });
+
+  cookieStore.set({
+    ...cookieOptions,
+    name: 'refreshToken',
+    value: '',
+  });
+
+  cookieStore.set({
+    ...cookieOptions,
+    name: 'permissions',
+    value: '',
+  });
+
+  return new NextResponse(
     JSON.stringify({ message: "Logout Successful" }),
     {
       status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
     }
   );
-
-  // Method 1: Delete cookies explicitly
-  res.cookies.delete("accessToken");
-  res.cookies.delete("refreshToken"); 
-  res.cookies.delete("permissions");
-
-  
-
-  res.cookies.set("accessToken", "", {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    expires: new Date(0), 
-    path: "/",
-  });
-
-  res.cookies.set("refreshToken", "", {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    expires: new Date(0), 
-    path: "/",
-  });
-
-  res.cookies.set("permissions", "", {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    expires: new Date(0), 
-    path: "/",
-  });
-
-  return res;
 }


### PR DESCRIPTION
This pull request refactors the logout API route to improve cookie deletion logic and ensure cookies are properly removed in both production and staging environments. The update uses the Next.js `cookies` API and applies consistent cookie options based on the environment.

**Cookie handling improvements:**

* Switched to using the Next.js `cookies` API for setting and deleting cookies, replacing the previous use of `res.cookies`.
* Added logic to determine if the environment is production or staging, and set the cookie domain and secure flag accordingly (using `.audease.co.uk` for production/staging).
* Standardized cookie deletion by setting `expires` to a past date and `maxAge` to 0, ensuring cookies are removed reliably.

**Response construction:**

* The API response is now always returned as a new `NextResponse` with explicit JSON content type and status code.…ve response handling